### PR TITLE
fix: align audit-log collector with logging/error-handling/tracing patterns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,12 @@
 #
 # Author: Alex Freidah
 #
-# Multi-stage Alpine build. Polls Cloudflare GraphQL API for firewall events
-# and HTTP traffic, ships to Loki and Prometheus.
+# Multi-stage Alpine build. Polls the Cloudflare GraphQL API for firewall events
+# and HTTP traffic and the REST Audit Logs API for account audit events, shipping
+# to Loki and Prometheus.
 # -------------------------------------------------------------------------------
 
-FROM --platform=$BUILDPLATFORM golang:1.26.1-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
 
 ARG VERSION=dev
 ARG TARGETOS

--- a/grafana/cloudflare-log-collector.json
+++ b/grafana/cloudflare-log-collector.json
@@ -121,14 +121,14 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "time() - cflog_last_poll_timestamp{zone=~\"$zone\"}",
-          "legendFormat": "{{dataset}} ({{zone}})"
+          "expr": "time() - max(cflog_last_poll_timestamp{zone=~\"$zone\"})",
+          "legendFormat": "since last poll"
         }
       ],
       "options": {
         "colorMode": "value",
         "graphMode": "none",
-        "textMode": "value_and_name",
+        "textMode": "value",
         "reduceOptions": { "calcs": ["lastNotNull"] }
       },
       "fieldConfig": {
@@ -634,9 +634,126 @@
     },
     {
       "type": "row",
+      "id": 30,
+      "title": "Audit Logs (from Cloudflare)",
+      "gridPos": { "x": 0, "y": 37, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "type": "timeseries",
+      "id": 31,
+      "title": "Audit Actions Over Time",
+      "description": "Account audit log actions over time, by action type",
+      "gridPos": { "x": 0, "y": 38, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (action) (rate(cflog_audit_events_total{account=~\"$account\"}[5m]))",
+          "legendFormat": "{{action}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "stacking": { "mode": "normal" }
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "id": 32,
+      "title": "Total Audit Events",
+      "description": "All-time audit events since last restart",
+      "gridPos": { "x": 12, "y": 38, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (account) (cflog_audit_events_total{account=~\"$account\"})",
+          "legendFormat": "{{account}}"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "purple", "value": null }]
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "id": 33,
+      "title": "Audit Actions Breakdown",
+      "description": "Audit events grouped by action type",
+      "gridPos": { "x": 18, "y": 38, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (action) (cflog_audit_events_total{account=~\"$account\"})",
+          "legendFormat": "{{action}}"
+        }
+      ],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "semi-dark-purple", "value": null }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "logs",
+      "id": 34,
+      "title": "Recent Audit Events (from Loki)",
+      "description": "Individual account audit events as shipped to Loki by the collector",
+      "gridPos": { "x": 12, "y": 42, "w": 12, "h": 4 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "expr": "{job=\"cloudflare\", type=\"audit\", account=~\"$account\"} | json",
+          "legendFormat": ""
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": false,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      }
+    },
+    {
+      "type": "row",
       "id": 40,
       "title": "Collector Logs",
-      "gridPos": { "x": 0, "y": 37, "w": 24, "h": 1 },
+      "gridPos": { "x": 0, "y": 46, "w": 24, "h": 1 },
       "collapsed": false
     },
     {
@@ -644,7 +761,7 @@
       "id": 41,
       "title": "Service Logs (collector process)",
       "description": "Stdout from the collector itself — poll results, errors, startup info. Click trace IDs to jump to Tempo.",
-      "gridPos": { "x": 0, "y": 38, "w": 24, "h": 10 },
+      "gridPos": { "x": 0, "y": 47, "w": 24, "h": 10 },
       "datasource": { "type": "loki", "uid": "loki" },
       "targets": [
         {
@@ -668,7 +785,7 @@
       "id": 42,
       "title": "HTTP Traffic Logs (raw Cloudflare data in Loki)",
       "description": "The raw HTTP traffic data points that the collector shipped to Loki from Cloudflare analytics",
-      "gridPos": { "x": 0, "y": 48, "w": 24, "h": 8 },
+      "gridPos": { "x": 0, "y": 57, "w": 24, "h": 8 },
       "datasource": { "type": "loki", "uid": "loki" },
       "targets": [
         {
@@ -696,6 +813,19 @@
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
         "query": "label_values(cflog_poll_total, zone)",
+        "includeAll": true,
+        "allValue": ".*",
+        "current": { "text": "All", "value": "$__all" },
+        "multi": true,
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "account",
+        "label": "Account",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": "label_values(cflog_audit_events_total, account)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },

--- a/internal/cloudflare/client.go
+++ b/internal/cloudflare/client.go
@@ -1,11 +1,14 @@
 // -------------------------------------------------------------------------------
-// Cloudflare GraphQL Client
+// Cloudflare API Client
 //
 // Authors: Alex Freidah, Aaron Florey
 //
-// HTTP client for the Cloudflare GraphQL Analytics API. Queries firewall events
-// and HTTP traffic statistics. Handles rate limiting, response parsing, and
-// seek-based pagination via datetime filters.
+// HTTP client for the Cloudflare APIs. Queries firewall events and HTTP traffic
+// statistics via the GraphQL Analytics API, and account audit logs via the REST
+// Audit Logs API. Handles rate limiting with exponential backoff, response
+// parsing, GraphQL datetime seek pagination, and REST cursor pagination. All
+// outbound requests share a single retrying executor that records the HTTP
+// status on the active trace span.
 // -------------------------------------------------------------------------------
 
 package cloudflare
@@ -25,6 +28,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -59,7 +63,7 @@ const (
 // CLIENT
 // -------------------------------------------------------------------------
 
-// Client talks to the Cloudflare GraphQL Analytics API.
+// Client talks to the Cloudflare GraphQL Analytics and REST Audit Logs APIs.
 type Client struct {
 	apiToken      string
 	endpoint      string
@@ -67,7 +71,7 @@ type Client struct {
 	httpClient    *http.Client
 }
 
-// NewClient creates a Cloudflare GraphQL client.
+// NewClient creates a Cloudflare API client.
 func NewClient(apiToken string) *Client {
 	return &Client{
 		apiToken:      apiToken,
@@ -389,58 +393,32 @@ func (c *Client) QueryAuditLogs(ctx context.Context, accountID string, since, be
 	return allEvents, nil
 }
 
-// doAuditQuery executes a single page request to the audit logs REST API.
+// doAuditQuery executes a single page request to the audit logs REST API. The
+// request is rebuilt for every attempt by the shared retrying executor, so no
+// per-request state leaks across retries.
 func (c *Client) doAuditQuery(ctx context.Context, endpoint string, since, before time.Time, cursor string) ([]AuditLogEvent, string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	respBody, statusCode, err := c.doWithRetry(ctx, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		q := req.URL.Query()
+		q.Set("since", since.UTC().Format(time.RFC3339))
+		q.Set("before", before.UTC().Format(time.RFC3339))
+		q.Set("limit", fmt.Sprintf("%d", auditQueryLimit))
+		q.Set("direction", "asc")
+		if cursor != "" {
+			q.Set("cursor", cursor)
+		}
+		req.URL.RawQuery = q.Encode()
+
+		req.Header.Set("Authorization", "Bearer "+c.apiToken)
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	})
 	if err != nil {
-		return nil, "", fmt.Errorf("create request: %w", err)
-	}
-
-	q := req.URL.Query()
-	q.Set("since", since.UTC().Format(time.RFC3339))
-	q.Set("before", before.UTC().Format(time.RFC3339))
-	q.Set("limit", fmt.Sprintf("%d", auditQueryLimit))
-	q.Set("direction", "asc")
-	if cursor != "" {
-		q.Set("cursor", cursor)
-	}
-	req.URL.RawQuery = q.Encode()
-
-	req.Header.Set("Authorization", "Bearer "+c.apiToken)
-	req.Header.Set("Content-Type", "application/json")
-
-	var respBody []byte
-	var statusCode int
-
-	for attempt := range maxRetries + 1 {
-		resp, err := c.httpClient.Do(req)
-		if err != nil {
-			return nil, "", fmt.Errorf("http request: %w", err)
-		}
-
-		respBody, err = io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
-		_ = resp.Body.Close()
-		if err != nil {
-			return nil, "", fmt.Errorf("read response: %w", err)
-		}
-
-		statusCode = resp.StatusCode
-
-		if !isRetryable(statusCode) || attempt == maxRetries {
-			break
-		}
-
-		delay := retryDelay(resp.Header, attempt)
-		slog.WarnContext(ctx, "Cloudflare API returned retryable status, backing off",
-			"status", statusCode, "attempt", attempt+1, "delay", delay)
-
-		retryTimer := time.NewTimer(delay)
-		select {
-		case <-retryTimer.C:
-		case <-ctx.Done():
-			retryTimer.Stop()
-			return nil, "", ctx.Err()
-		}
+		return nil, "", err
 	}
 
 	if statusCode != http.StatusOK {
@@ -474,59 +452,26 @@ func (c *Client) doQuery(ctx context.Context, zoneID, query string, variables ma
 	)
 	defer span.End()
 
-	reqBody := graphQLRequest{
-		Query:     query,
-		Variables: variables,
-	}
-
-	payload, err := json.Marshal(reqBody)
+	payload, err := json.Marshal(graphQLRequest{Query: query, Variables: variables})
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	var respBody []byte
-	var statusCode int
-
-	for attempt := range maxRetries + 1 {
+	respBody, statusCode, err := c.doWithRetry(ctx, func() (*http.Request, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(payload))
 		if err != nil {
-			return nil, fmt.Errorf("create request: %w", err)
+			return nil, err
 		}
 
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Authorization", "Bearer "+c.apiToken)
-
-		resp, err := c.httpClient.Do(req)
-		if err != nil {
-			return nil, fmt.Errorf("http request: %w", err)
-		}
-
-		respBody, err = io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
-		_ = resp.Body.Close()
-		if err != nil {
-			return nil, fmt.Errorf("read response: %w", err)
-		}
-
-		statusCode = resp.StatusCode
-
-		if !isRetryable(statusCode) || attempt == maxRetries {
-			break
-		}
-
-		delay := retryDelay(resp.Header, attempt)
-		slog.WarnContext(ctx, "Cloudflare API returned retryable status, backing off",
-			"status", statusCode, "attempt", attempt+1, "delay", delay)
-
-		retryTimer := time.NewTimer(delay)
-		select {
-		case <-retryTimer.C:
-		case <-ctx.Done():
-			retryTimer.Stop()
-			return nil, ctx.Err()
-		}
+		return req, nil
+	})
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
 	}
-
-	span.SetAttributes(attribute.Int("http.status_code", statusCode))
 
 	if statusCode != http.StatusOK {
 		err := fmt.Errorf("HTTP %d: %s", statusCode, string(respBody))
@@ -550,6 +495,56 @@ func (c *Client) doQuery(ctx context.Context, zoneID, query string, variables ma
 	}
 
 	return gqlResp.Data, nil
+}
+
+// doWithRetry sends the request produced by buildReq, retrying on retryable
+// status codes with exponential backoff that honors Retry-After. The request is
+// rebuilt for every attempt so no per-request state leaks across retries. The
+// final HTTP status code is recorded on the active span and returned alongside
+// the response body for the caller to interpret.
+func (c *Client) doWithRetry(ctx context.Context, buildReq func() (*http.Request, error)) ([]byte, int, error) {
+	var respBody []byte
+	var statusCode int
+
+	for attempt := range maxRetries + 1 {
+		req, err := buildReq()
+		if err != nil {
+			return nil, 0, fmt.Errorf("create request: %w", err)
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, 0, fmt.Errorf("http request: %w", err)
+		}
+
+		respBody, err = io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, 0, fmt.Errorf("read response: %w", err)
+		}
+
+		statusCode = resp.StatusCode
+
+		if !isRetryable(statusCode) || attempt == maxRetries {
+			break
+		}
+
+		delay := retryDelay(resp.Header, attempt)
+		slog.WarnContext(ctx, "Cloudflare API returned retryable status, backing off",
+			"status", statusCode, "attempt", attempt+1, "delay", delay)
+
+		retryTimer := time.NewTimer(delay)
+		select {
+		case <-retryTimer.C:
+		case <-ctx.Done():
+			retryTimer.Stop()
+			return nil, statusCode, ctx.Err()
+		}
+	}
+
+	trace.SpanFromContext(ctx).SetAttributes(attribute.Int("http.status_code", statusCode))
+
+	return respBody, statusCode, nil
 }
 
 // isRetryable returns true for HTTP status codes that warrant a retry.

--- a/internal/collector/audit.go
+++ b/internal/collector/audit.go
@@ -5,8 +5,9 @@
 //
 // Polls the Cloudflare Account Audit Logs REST API on a configurable interval
 // and ships events to Loki as structured JSON log lines. Tracks the last-seen
-// event timestamp for seek-based pagination to avoid duplicates across polls.
-// Each poll cycle is wrapped in an OpenTelemetry span for trace correlation.
+// event timestamp as a seek cursor and dedupes the inclusive `since` boundary
+// by event ID so no event ships twice across polls. Each poll cycle is wrapped
+// in an OpenTelemetry span for trace correlation.
 // -------------------------------------------------------------------------------
 
 package collector
@@ -54,6 +55,11 @@ type AuditCollector struct {
 	pollInterval time.Duration
 	lastSeen     time.Time
 	batchSize    int
+
+	// shippedAtCursor holds the IDs of events already shipped at the lastSeen
+	// boundary, so they can be dropped if the API returns them again. See
+	// dropAlreadyShipped for why audit needs this and firewall does not.
+	shippedAtCursor map[string]struct{}
 }
 
 // NewAuditCollector creates an audit log collector for the given account
@@ -121,6 +127,9 @@ func (c *AuditCollector) poll(ctx context.Context) {
 	metrics.PollDuration.WithLabelValues("audit", c.accountName).Observe(time.Since(start).Seconds())
 	metrics.LastPollTimestamp.WithLabelValues("audit", c.accountName).Set(float64(time.Now().Unix()))
 
+	// Drop events already shipped at the previous cursor boundary.
+	events = c.dropAlreadyShipped(events)
+
 	span.SetAttributes(attribute.Int("cflog.event_count", len(events)))
 
 	if len(events) == 0 {
@@ -140,18 +149,57 @@ func (c *AuditCollector) poll(ctx context.Context) {
 
 	slog.InfoContext(ctx, "Audit events pushed to Loki", "account", c.accountName, "count", len(events))
 
-	// --- Update metrics ---
+	// Update metrics.
 	for i := range events {
 		metrics.AuditEventsTotal.WithLabelValues(events[i].Action.Type, c.accountName).Inc()
 	}
 
-	// --- Advance cursor to the last event's timestamp ---
+	// Advance cursor to the last event's timestamp and record the IDs sharing
+	// that timestamp so the next poll can drop them if the API returns them again.
 	lastEvent := events[len(events)-1]
-	if t, err := time.Parse(time.RFC3339Nano, lastEvent.Action.Time); err == nil {
+	if t, ok := parseEventTime(lastEvent.Action.Time); ok {
 		c.lastSeen = t
-	} else if t, err := time.Parse(time.RFC3339, lastEvent.Action.Time); err == nil {
-		c.lastSeen = t
+		c.shippedAtCursor = boundaryIDs(events, lastEvent.Action.Time)
+	} else {
+		slog.WarnContext(ctx, "Unparseable audit event timestamp, cursor not advanced",
+			"account", c.accountName, "time", lastEvent.Action.Time)
 	}
+}
+
+// dropAlreadyShipped removes events already shipped on a previous poll. The
+// audit logs REST API exposes only a `since` lower bound (with no exclusive
+// variant and undocumented inclusivity), so the event(s) at the cursor boundary
+// can be returned again on the next poll. The firewall collector avoids this
+// with the GraphQL datetime_gt (exclusive) filter; the REST API offers no such
+// option, so audit dedupes the boundary by event ID instead. This is safe
+// whether `since` is inclusive or exclusive: when exclusive, the boundary set
+// simply never matches.
+func (c *AuditCollector) dropAlreadyShipped(events []cloudflare.AuditLogEvent) []cloudflare.AuditLogEvent {
+	if len(c.shippedAtCursor) == 0 {
+		return events
+	}
+
+	filtered := events[:0]
+	for i := range events {
+		if _, dup := c.shippedAtCursor[events[i].ID]; dup {
+			continue
+		}
+		filtered = append(filtered, events[i])
+	}
+	return filtered
+}
+
+// boundaryIDs returns the IDs of events whose timestamp equals the cursor
+// boundary. Comparing the raw timestamp string avoids a re-parse and matches
+// exactly what the API returned.
+func boundaryIDs(events []cloudflare.AuditLogEvent, boundary string) map[string]struct{} {
+	ids := make(map[string]struct{})
+	for i := range events {
+		if events[i].Action.Time == boundary {
+			ids[events[i].ID] = struct{}{}
+		}
+	}
+	return ids
 }
 
 // shipToLoki sends audit events to Loki as JSON log lines in batches.

--- a/internal/collector/audit_test.go
+++ b/internal/collector/audit_test.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 	"time"
 
@@ -226,6 +227,69 @@ func TestAuditShipToLoki_InvalidTimestamp(t *testing.T) {
 
 	if len(received) == 0 {
 		t.Error("expected Loki push request even with invalid timestamp")
+	}
+}
+
+// auditCursorServer serves a different page of audit events per poll. The first
+// poll returns e1 and e2; the second returns e2 (the inclusive `since`
+// boundary) and e3, simulating Cloudflare re-returning the boundary event.
+func auditCursorServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	var pollCount int
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pollCount++
+		w.Header().Set("Content-Type", "application/json")
+		body := `{"success":true,"result":[
+			{"id":"e2","action":{"type":"settings.modify","time":"2026-03-13T10:00:05Z"}},
+			{"id":"e3","action":{"type":"settings.modify","time":"2026-03-13T10:00:09Z"}}
+		],"result_info":{"count":2,"cursor":""}}`
+		if pollCount == 1 {
+			body = `{"success":true,"result":[
+				{"id":"e1","action":{"type":"settings.modify","time":"2026-03-13T10:00:00Z"}},
+				{"id":"e2","action":{"type":"settings.modify","time":"2026-03-13T10:00:05Z"}}
+			],"result_info":{"count":2,"cursor":""}}`
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func TestAuditPoll_DedupesCursorBoundary(t *testing.T) {
+	cfServer := auditCursorServer(t)
+	t.Cleanup(cfServer.Close)
+
+	var shipped []string
+	lokiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var push struct {
+			Streams []struct {
+				Values [][]string `json:"values"`
+			} `json:"streams"`
+		}
+		_ = json.Unmarshal(body, &push)
+		for _, s := range push.Streams {
+			for _, v := range s.Values {
+				var ev cloudflare.AuditLogEvent
+				if json.Unmarshal([]byte(v[1]), &ev) == nil {
+					shipped = append(shipped, ev.ID)
+				}
+			}
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(lokiServer.Close)
+
+	cfg := auditTestConfig(loki.NewClient(lokiServer.URL, "fake"), 100)
+	cfg.CF = cloudflare.NewTestClient(cfServer.URL, "test-token")
+	c := NewAuditCollector(cfg)
+
+	c.poll(context.Background())
+	c.poll(context.Background())
+
+	// e2 sits on the cursor boundary and is returned by both polls; it must
+	// ship exactly once.
+	want := []string{"e1", "e2", "e3"}
+	if !slices.Equal(shipped, want) {
+		t.Errorf("shipped = %v, want %v (boundary event e2 must not ship twice)", shipped, want)
 	}
 }
 

--- a/internal/collector/cursor.go
+++ b/internal/collector/cursor.go
@@ -1,0 +1,28 @@
+// -------------------------------------------------------------------------------
+// Collector Cursor Helpers
+//
+// Author: Alex Freidah
+//
+// Shared helpers for advancing the seek cursor that collectors use to avoid
+// re-ingesting events across poll cycles. Timestamp parsing is centralized here
+// so every dataset accepts the same RFC3339 layouts and handles unparseable
+// values identically.
+// -------------------------------------------------------------------------------
+
+package collector
+
+import "time"
+
+// parseEventTime parses an event timestamp, accepting both the RFC3339Nano and
+// RFC3339 layouts returned by the Cloudflare APIs. The boolean result is false
+// when neither layout matches, letting callers log and skip cursor advancement
+// rather than silently stalling on an unparseable timestamp.
+func parseEventTime(s string) (time.Time, bool) {
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}

--- a/internal/collector/firewall.go
+++ b/internal/collector/firewall.go
@@ -147,8 +147,11 @@ func (c *FirewallCollector) poll(ctx context.Context) {
 
 	// --- Advance cursor to the last event's timestamp ---
 	lastEvent := events[len(events)-1]
-	if t, err := time.Parse(time.RFC3339Nano, lastEvent.Datetime); err == nil {
+	if t, ok := parseEventTime(lastEvent.Datetime); ok {
 		c.lastSeen = t
+	} else {
+		slog.WarnContext(ctx, "Unparseable firewall event timestamp, cursor not advanced",
+			"zone", c.zoneName, "datetime", lastEvent.Datetime)
 	}
 }
 

--- a/internal/loki/client.go
+++ b/internal/loki/client.go
@@ -5,7 +5,8 @@
 //
 // HTTP client for the Loki push API (POST /loki/api/v1/push). Batches log
 // entries and sends them as JSON streams with configurable labels and tenant ID.
-// Used to ship Cloudflare firewall events into the cluster's Loki instance.
+// Used to ship Cloudflare firewall events, HTTP traffic, and audit logs into the
+// cluster's Loki instance.
 // -------------------------------------------------------------------------------
 
 package loki

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -18,6 +18,10 @@ import (
 // POLL METRICS
 // -------------------------------------------------------------------------
 
+// The "zone" label identifies the polled scope. For the firewall and http
+// datasets it holds the zone name; for the audit dataset it holds the account
+// name, since audit logs are scoped per account rather than per zone.
+
 // PollTotal counts poll attempts by dataset, zone, and status.
 var PollTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "cflog_poll_total",

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.1-alpine AS godoc
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS godoc
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
Closes #38.

Brings the externally contributed account audit-log path (PR #35, adapted from #33) in line with the established firewall/HTTP conventions, hardens its dedup, and refreshes docs. Also updates the Grafana dashboard and unblocks the container builds.

## Code
- **Client tracing parity** — extracted a shared `doWithRetry` executor used by both the GraphQL and audit REST paths. It rebuilds the request on every attempt (audit previously reused one `*http.Request` across retries) and records `http.status_code` on the active span, so audit client spans now match GraphQL.
- **Boundary dedup** — the audit cursor boundary is deduped by event ID. The REST `since` bound has no exclusive variant (unlike GraphQL `datetime_gt`), so the boundary event could be re-ingested each poll. Safe whether `since` is inclusive or exclusive. Covered by a new `TestAuditPoll_DedupesCursorBoundary`.
- **Silent cursor stall** — centralized timestamp parsing in `parseEventTime` (shared by firewall + audit) and log a warning when an unparseable timestamp would otherwise stall the cursor.
- **Metric label** — documented that the `zone` label carries the account name for the audit dataset.

## Docs
- Refreshed `cloudflare` and `loki` client headers/godoc (audit REST API, cursor pagination, multi-dataset shipping).

## Build
- Bumped the `golang` base image to `1.26.4-alpine` in `Dockerfile` and `web/Dockerfile` to satisfy the `go.mod` toolchain floor under `GOTOOLCHAIN=local`.

## Grafana
- Added an Audit Logs dashboard row (actions over time, totals, breakdown, recent events) and an `$account` template variable.
- Aggregated the "Time Since Last Poll" panel with `max()` so it shows a single freshness value instead of one line per dataset/zone.

## Verification
- `go test ./...` green (incl. the new dedup test); `golangci-lint run`: 0 issues.